### PR TITLE
(util/table_1/table_4) fix best-combo selection (turn_penalty path, model+merge fix, ablation params) // (figure_2/4/5/6) layout & filename adjustments

### DIFF
--- a/src/Figure/figure_1.py
+++ b/src/Figure/figure_1.py
@@ -31,7 +31,7 @@ class ResultShowcaseFigure(FigureGenerator):
             return None
         canvas = stage["image"].copy()
         fr.draw_strands(canvas, final, dots=True)
-        return canvas, f"_ap{ap20:.2f}"
+        return canvas, ""
 
     def frame_ap20(self, image_id, final):
         """최종 linestring을 RLE 예측으로 변환해 프레임 AP20을 계산."""

--- a/src/Figure/figure_2.py
+++ b/src/Figure/figure_2.py
@@ -21,7 +21,7 @@ class PipelineFigure(FigureGenerator):
     """한 장면이 분할→벡터화→정제→병합 단계를 거치는 흐름을 1×5로 보인다."""
 
     name = "Figure_2"
-    min_trim_drop = 20.0
+    min_trim_drop = 50.0   # center_line 트리밍이 강한(제거 ≥ 50px) 프레임만
     ap20_min = 0.50
 
     def build_figure(self, image_id, path):

--- a/src/Figure/figure_2.py
+++ b/src/Figure/figure_2.py
@@ -1,6 +1,6 @@
 """Figure 2 — 파이프라인 개요 (1×5 가로 콜라주).
 
-패널: (a) 원본+GT | (b) 분할(8클래스) | (c) 초기 linestring(정제 전) | (d) 정제 후 | (e) 최종 병합.
+패널: (a) 원본+GT | (b) 분할(평가 클래스) | (c) 초기 linestring(정제 전) | (d) 정제 후 | (e) 최종 병합.
 center_line 평행 겹침 트리밍이 뚜렷한(제거 ≥ 50px) 프레임만 출력한다.
 """
 import os
@@ -35,7 +35,7 @@ class PipelineFigure(FigureGenerator):
             return None
         if not self.is_good_frame(stage, image_id):
             return None
-        return self.compose(stage, image_id), f"_drop{int(trim['len_drop'])}"
+        return self.compose(stage, image_id), ""
 
     def is_good_frame(self, stage, image_id):
         """프레임 AP20이 기준 이상인 깔끔한 예시인지 판정."""

--- a/src/Figure/figure_4.py
+++ b/src/Figure/figure_4.py
@@ -1,13 +1,12 @@
-"""Figure 4 — 벡터화: 세선화 + 곡률 인지 추적 + 잔여 재추출 (1×4 가로 콜라주).
+"""Figure 4 — 벡터화: 곡률 인지 추적 + 잔여 재추출 (1×3 가로 콜라주).
 
 데모 클래스 = center_line(한 색). 패널:
-(a) 분할 블롭 | (b) 1픽셀 골격 | (c) 정렬 샘플점(외삽 없음) | (d) 잔여 재추출 결과(1차=회색, 복원=주황).
-잔여 재추출로 center_line이 복원된 프레임만 출력한다(패널 (d)가 의미를 갖도록).
+(a) 원본 영상 + 분할 블롭 | (b) 정렬 샘플점(외삽 없음) | (c) 잔여 재추출 결과(1차=회색, 복원=주황).
+잔여 재추출로 center_line이 복원된 프레임만 출력한다(패널 (c)가 의미를 갖도록).
 """
 import os
 import sys
 
-import cv2
 import numpy as np
 
 _CUR = os.path.dirname(os.path.abspath(__file__))
@@ -35,51 +34,41 @@ class VectorizationFigure(FigureGenerator):
         pred_img = self.read_prediction(image_id)
         if not fm.has_color(pred_img, cfg.ID2BGR.get(self.cls)):
             return None
-        self._detector._img_shape = pred_img.shape[:2]
-        blob, line_map, _ = self._detector.class_skeleton(pred_img, self.cls)
         stage = self._detector.stage_linestrings(path, do_merge=False)
         residual = self._center_lines(stage["res"])
         if sum(fm.arc_length(s.points) for s in residual) < self.min_residual_len:
             return None
         first = self._center_lines(stage["first"])
-        return self.compose(pred_img, line_map, first, residual), ""
+        return self.compose(stage["image"], pred_img, first, residual), ""
 
     def _center_lines(self, strands):
         return [s for s in strands if s.class_id == self.cls]
 
-    def compose(self, pred_img, line_map, first, residual):
-        """네 패널을 검은 여백으로 가로 결합한다."""
+    def compose(self, image, pred_img, first, residual):
+        """세 패널을 검은 여백으로 가로 결합한다."""
         height, width = self._detector._img_shape
         panels = [
-            self.blob_panel(pred_img, height, width),
-            self.skeleton_panel(line_map, height, width),
+            self.blob_panel(image, pred_img, height, width),
             self.sample_panel(first, height, width),
             self.residual_panel(first, residual, height, width),
         ]
         return fr.concat_horizontal(panels)
 
-    def blob_panel(self, pred_img, height, width):
-        """(a) 분할 블롭을 렌더색으로."""
-        canvas = fr.make_white_canvas(height, width)
+    def blob_panel(self, image, pred_img, height, width):
+        """(a) 원본 영상 위에 분할 블롭을 렌더색으로 칠한다."""
+        canvas = image.copy()
         canvas[np.all(pred_img == cfg.ID2BGR.get(self.cls), axis=-1)] = self.render
         return canvas
 
-    def skeleton_panel(self, line_map, height, width):
-        """(b) 1픽셀 골격(가시성 위해 약간 dilate)."""
-        canvas = fr.make_white_canvas(height, width)
-        skeleton = cv2.dilate((line_map > 0).astype(np.uint8), np.ones((2, 2), np.uint8))
-        canvas[skeleton > 0] = self.render
-        return canvas
-
     def sample_panel(self, first, height, width):
-        """(c) 정렬 샘플점 폴리라인 + 끝점 점(외삽은 표시하지 않음)."""
+        """(b) 정렬 샘플점 폴리라인 + 끝점 점(외삽은 표시하지 않음)."""
         canvas = fr.make_white_canvas(height, width)
         for strand in first:
             fr.draw_strand(canvas, strand.points, self.render, thickness=3, draw_dots=True)
         return canvas
 
     def residual_panel(self, first, residual, height, width):
-        """(d) 1차 선(회색) 위에 잔여로 복원된 선(주황)을 오버레이(끝점 점 포함)."""
+        """(c) 1차 선(회색) 위에 잔여로 복원된 선(주황)을 오버레이(끝점 점 포함)."""
         canvas = fr.make_white_canvas(height, width)
         for strand in first:
             fr.draw_strand(canvas, strand.points, self.gray, thickness=3, draw_dots=True)

--- a/src/Figure/figure_4.py
+++ b/src/Figure/figure_4.py
@@ -21,7 +21,7 @@ from figure_base import FigureGenerator
 
 
 class VectorizationFigure(FigureGenerator):
-    """center_line의 블롭→골격→샘플점→잔여복원 벡터화 과정을 1×4로 보인다."""
+    """center_line의 블롭→샘플점→잔여복원 벡터화 과정을 1×3으로 보인다."""
 
     name = "Figure_4"
     cls = fm.CENTER_LINE_ID

--- a/src/Figure/figure_5.py
+++ b/src/Figure/figure_5.py
@@ -2,7 +2,7 @@
 
 패널: (a) 원본 영상 + 분할 오버레이(장면 맥락) | (b) 정제 전 center_line(겹친 중복 본체)
       | (c) 트리밍 후(중복 본체 절단, 분기 가지 보존).
-center_line 트리밍 제거량 ≥ 20px 인 프레임만 출력하며, 파일명에 제거 길이를 기록한다.
+center_line 트리밍 제거량 ≥ 20px 인 프레임만 출력한다.
 """
 import os
 import sys
@@ -33,7 +33,7 @@ class RefinementFigure(FigureGenerator):
         trim = fm.measure_trim(stage)
         if trim["len_drop"] < self.min_trim_drop:
             return None
-        return self.compose(stage), f"_drop{int(trim['len_drop'])}"
+        return self.compose(stage), ""
 
     def compose(self, stage):
         """장면 맥락 + 정제 전/후 center_line 패널을 검은 여백으로 가로 결합한다."""

--- a/src/Figure/figure_render.py
+++ b/src/Figure/figure_render.py
@@ -157,7 +157,7 @@ def _apply_render_colors(out, pred_img, exclude_ids):
 
 
 def overlay_segmentation(image, pred_img, exclude_ids, alpha=0.5):
-    """원본 영상 위에 분할 예측을 클래스 렌더색으로 반투명 오버레이한다(제외 클래스 제외)."""
+    """원본 영상 위에 분할 예측을 클래스 렌더색으로 오버레이한다(alpha=불투명도, 제외 클래스 제외)."""
     out = image.copy()
     for class_id, original in cfg.ID2BGR.items():
         if class_id == 0 or class_id in exclude_ids:

--- a/src/Table/table_1.py
+++ b/src/Table/table_1.py
@@ -14,27 +14,29 @@ class Table1Builder:
         self.num_params_df = pd.read_csv(num_params_path)
 
     def build(self):
-        thickness, stride, extend_len = self._find_best_params()
-        result = self._filter_and_sort(thickness, stride, extend_len)
+        thickness, stride, extend_len, turn = self._find_best_params()
+        result = self._filter_and_sort(thickness, stride, extend_len, turn)
         result.drop_duplicates(inplace=True, ignore_index=True)
         print('intermediate result\n', result.to_string(index=False))
         result = self._add_params_column(result)
         self._save(result)
 
     def _find_best_params(self):
-        best_row_idx = self.df['AP20'].idxmax()
-        best_row = self.df.loc[best_row_idx]
+        best_row = self.df.loc[self.df['AP20'].idxmax()]
         thickness = best_row['thicknesses']
         stride = best_row['sample_strides']
         extend_len = best_row['extend_lens']
-        print(f"Best params — thicknesses={thickness}, sample_strides={stride}, extend_lens={extend_len}, max AP20={best_row['AP20']:.6f}")
-        return thickness, stride, extend_len
+        turn = best_row['turn_penalties']
+        print(f"Best params — thicknesses={thickness}, sample_strides={stride}, "
+              f"extend_lens={extend_len}, turn_penalties={turn}, max AP20={best_row['AP20']:.6f}")
+        return thickness, stride, extend_len, turn
 
-    def _filter_and_sort(self, thickness, stride, extend_len):
+    def _filter_and_sort(self, thickness, stride, extend_len, turn):
         algo_mask = (
             (self.df['thicknesses'] == thickness) &
             (self.df['sample_strides'] == stride) &
-            (self.df['extend_lens'] == extend_len)
+            (self.df['extend_lens'] == extend_len) &
+            (self.df['turn_penalties'] == turn)
         )
         filtered = self.df[algo_mask].copy()
         return filtered.sort_values(
@@ -45,11 +47,7 @@ class Table1Builder:
 
     def _add_params_column(self, df):
         params_map = self.num_params_df.set_index('model')['total_params_M']
-        print('params_map\n', params_map)
-        df['params(M)'] = df.apply(
-            lambda row: params_map.get(row['model_name']) if pd.isna(row['merge_count']) else None,
-            axis=1
-        )
+        df['params(M)'] = df['model_name'].map(params_map)
         return df
 
     def _save(self, result):

--- a/src/Table/table_4.py
+++ b/src/Table/table_4.py
@@ -7,8 +7,8 @@ import config as cfg
 
 
 class Table4Builder:
-    ABLATION_PARAMS = ['merge_count', 'sample_strides', 'extend_lens']
-    METRICS = ['instances', 'AP20', 'mIoU']
+    ABLATION_PARAMS = ['sample_strides', 'extend_lens', 'turn_penalties']
+    METRICS = ['instances', 'AP10', 'AP20', 'AP50', 'mIoU']
 
     def __init__(self, total_csv_path, save_path):
         self.total_csv_path = total_csv_path
@@ -16,31 +16,37 @@ class Table4Builder:
         self.df = pd.read_csv(total_csv_path)
 
     def build(self):
-        model_name = self._find_best_model()
-        result = self._build_ablation_table(model_name)
-        self._save(result, model_name)
+        model_name, merge_count = self._find_best()
+        result = self._build_ablation_table(model_name, merge_count)
+        self._save(result, model_name, merge_count)
 
-    def _find_best_model(self):
+    def _find_best(self):
         detector_df = self.df[self.df['instances'] > 0]
         best_row = detector_df.loc[detector_df['AP20'].idxmax()]
-        best_model = best_row['model_name']
-        print(f"Best model for ablation: {best_model} (AP20={best_row['AP20']:.4f})")
-        return best_model
+        model_name = best_row['model_name']
+        merge_count = int(best_row['merge_count'])
+        print(f"Ablation 고정값 — model={model_name}, merge_count={merge_count} "
+              f"(AP20={best_row['AP20']:.4f})")
+        return model_name, merge_count
 
-    def _build_ablation_table(self, model_name):
-        model_df = self.df[
+    def _build_ablation_table(self, model_name, merge_count):
+        mask = (
             (self.df['model_name'] == model_name) &
+            (self.df['merge_count'] == merge_count) &
             (self.df['instances'] > 0)
-        ].copy()
+        )
+        model_df = self.df[mask].copy()
         cols = self.ABLATION_PARAMS + self.METRICS
         return model_df[cols].sort_values(self.ABLATION_PARAMS).reset_index(drop=True)
 
-    def _save(self, result, model_name):
-        result[['merge_count', 'instances']] = result[['merge_count', 'instances']].astype(int)
-        result[['AP20', 'mIoU']] = (result[['AP20', 'mIoU']] * 100).round(2)  # % 단위로 변환
+    def _save(self, result, model_name, merge_count):
+        int_cols = ['sample_strides', 'extend_lens', 'turn_penalties', 'instances']
+        result[int_cols] = result[int_cols].astype(int)
+        metric_cols = ['AP10', 'AP20', 'AP50', 'mIoU']
+        result[metric_cols] = (result[metric_cols] * 100).round(2)  # % 단위로 변환
         os.makedirs(os.path.dirname(self.save_path), exist_ok=True)
         result.to_csv(self.save_path, index=False, encoding='utf-8')
-        print(f"\nAblation Study — model: {model_name}")
+        print(f"\nAblation Study — model: {model_name}, merge_count: {merge_count} (고정)")
         print(f"Saved to: {self.save_path}")
         print(result.to_string(index=False))
         print('table 4 shape:', result.shape)

--- a/src/util.py
+++ b/src/util.py
@@ -26,14 +26,15 @@ def find_best_pred_json_path(csv_path):
     t = int(best_row['thicknesses'])
     s = int(best_row['sample_strides'])
     e = int(best_row['extend_lens'])
-    
+    tp = int(best_row['turn_penalties'])
+
     print(f"Best target: model={model_name}, merge_count={merge_count}, AP20={best_row['AP20']:.6f}")
-    
+
     model_dir = cfg.MODEL_PREFIX + model_name
-    param_dir = f"thick={t},stride={s},extend={e}"
+    param_dir = f"thick={t},stride={s},extend={e},turn={tp}"
     filename = "origin" if merge_count == 0 else f"merge{merge_count}"
     pred_json_path = os.path.join(cfg.RESULT_PATH, model_dir, param_dir, f"coco_pred_instances_{filename}.json")
-    
+
     return model_name, merge_count, pred_json_path
 
 


### PR DESCRIPTION
## 개요
Table 생성 스크립트를 현재 실험(turn_penalty 스윕·merge_count·bicycle_lane 포함 9클래스)에 맞게 바로잡고, 논문용 figure 구성·파일명을 정리한다.

## Table 스크립트 수정 (`76fc6e3`)
- **util.find_best_pred_json_path**: best-combo 예측 JSON 경로에 `turn` 누락 버그 수정(`thick=...,turn=N` 형식) → table_2가 pred를 못 찾던 문제 해결.
- **table_1**: thick/stride/extend/**turn 4개 모두** 최적으로 고정해 (model × merge_count)만 비교, `params(M)` 모델별 채움.
- **table_4**: model·merge_count를 최적으로 **고정**하고 sample_stride/extend/**turn**을 ablation(기존엔 merge_count를 vary하고 turn 누락).
- 검증: table_2 클래스 평균 AP20/mIoU = table_1 (통과). bicycle_lane 포함 9클래스 정상.

## Figure 구성 조정
- **figure_4** (`5c00172`): thinning(1픽셀 골격) 패널 제거 → **1×3**, (a)를 원본 영상+블롭으로.
- **figure_2**: center_line 트리밍 선별 임계 20→**50px**(강한 트리밍 예시만).
- **figure_5/6**: (이전 main 작업) 1×3 레이아웃 — figure_6 외삽 강조색은 연회색(LightSlateGray).
- **파일명 좌표화** (`f7a3521`): figure_1/2/5에서 `_ap`/`_drop` 접미사 제거 → 원본 좌표명만(`{좌표}.png`).
- docstring을 현재 패널 구성에 맞게 동기화.

## 검증
- 전 figure 스크립트 컴파일 OK, 스모크로 레이아웃 시각 확인. Table 3종 정상 생성·검증 통과.
- config.py(결과 폴더·EXCLUDE_IDS)·manuscript·FILTER_CONDITIONS는 gitignore라 비포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)